### PR TITLE
Add fallback for item position logging

### DIFF
--- a/HelloRepoPlugin/HelloRepoPlugin.cs
+++ b/HelloRepoPlugin/HelloRepoPlugin.cs
@@ -213,6 +213,18 @@ public sealed class RepoAgentExtended : BaseUnityPlugin
                 list.Add(new ItemPos(v.transform.position));
             }
         }
+
+        // Если первый способ не дал результатов, пытаемся получить их из ItemManager
+        if (list.Count == 0 && ItemManager.instance?.spawnedItems != null)
+        {
+            foreach (var item in ItemManager.instance.spawnedItems)
+            {
+                if (item == null) continue;
+                if (list.Count >= MAX_ITEMS) break;
+
+                list.Add(new ItemPos(item.transform.position));
+            }
+        }
         o.item_pos = list.ToArray();
         o.item_count = o.item_pos.Length;
 


### PR DESCRIPTION
## Summary
- extend item position gathering in `BuildObs`
- if `ValuableDirector` list is empty, pull items from `ItemManager.spawnedItems`

## Testing
- `dotnet build -c Release HelloRepoPlugin.sln` *(fails: `dotnet` not installed)*